### PR TITLE
Fix numpy version to what networkx==2.4 expects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 networkx==2.4
+numpy==1.20.1
 paho-mqtt==1.5.0
 rhasspy-asr-kaldi~=0.7.0
 rhasspy-hermes~=0.6.0


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for details